### PR TITLE
Feature/improved MV3 service worker suspension handling

### DIFF
--- a/packages/example-extension/src/entrypoints/background/index.ts
+++ b/packages/example-extension/src/entrypoints/background/index.ts
@@ -35,5 +35,7 @@ export default defineBackground(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).pegasusEventBus = eventBus;
 
-  initExtensionStoreBackend();
+  initExtensionStoreBackend().catch((err) =>
+    console.error('Error initializing extension store backend', err),
+  );
 });

--- a/packages/example-extension/src/renderStoreCounterUI.ts
+++ b/packages/example-extension/src/renderStoreCounterUI.ts
@@ -22,15 +22,20 @@ export function renderStoreCounterUI(contextName: string, props: Props = {}) {
       // eslint-disable-next-line no-console
       console.log(`@webext/pegasus ${contextName}: received tab ID: ${tabID}`);
 
-      let counter = store.getState().simpleCounterForTab[tabID];
+      let counter = store.getState().simpleCounterForTab[tabID] ?? 0;
       // eslint-disable-next-line no-console
       console.log(
         `@webext/pegasus ${contextName}: counter current value: ${counter}`,
       );
       props.onValueChange?.(counter);
 
+      const counterCTA = document.createElement('button');
+      document.body?.appendChild(counterCTA);
+      const updateCounterCTA = () => counterCTA.innerText = `Increment counter (${contextName}): ${counter}`;
+      updateCounterCTA();
+
       store.subscribe((state) => {
-        const newCounter = state.simpleCounterForTab[tabID];
+        const newCounter = state.simpleCounterForTab[tabID] ?? 0;
         if (newCounter !== counter) {
           counter = store.getState().simpleCounterForTab[tabID];
           // eslint-disable-next-line no-console
@@ -39,15 +44,13 @@ export function renderStoreCounterUI(contextName: string, props: Props = {}) {
             state,
           );
           props.onValueChange?.(counter);
+          updateCounterCTA();
         }
       });
 
-      const counterCTA = document.createElement('button');
-      counterCTA.innerText = `Increment counter33 (${contextName})`;
       counterCTA.onclick = () => {
         store.getState().bumpCounterForTab(tabID);
       };
-      document.body?.appendChild(counterCTA);
     })
     .catch((err) =>
       console.error(

--- a/packages/example-extension/src/renderStoreCounterUI.ts
+++ b/packages/example-extension/src/renderStoreCounterUI.ts
@@ -31,13 +31,14 @@ export function renderStoreCounterUI(contextName: string, props: Props = {}) {
 
       const counterCTA = document.createElement('button');
       document.body?.appendChild(counterCTA);
-      const updateCounterCTA = () => counterCTA.innerText = `Increment counter (${contextName}): ${counter}`;
+      const updateCounterCTA = () =>
+        (counterCTA.innerText = `Increment counter (${contextName}): ${counter}`);
       updateCounterCTA();
 
       store.subscribe((state) => {
         const newCounter = state.simpleCounterForTab[tabID] ?? 0;
         if (newCounter !== counter) {
-          counter = store.getState().simpleCounterForTab[tabID];
+          counter = store.getState().simpleCounterForTab[tabID] ?? 0;
           // eslint-disable-next-line no-console
           console.log(
             `@webext/pegasus ${contextName}: counter NEW value: ${counter}`,

--- a/packages/example-extension/src/store.ts
+++ b/packages/example-extension/src/store.ts
@@ -36,6 +36,8 @@ export const useExtensionStore = create<ExtensionState>()(
 const STORE_NAME = 'ExtensionStore';
 
 export const initExtensionStoreBackend = () =>
-  initPegasusZustandStoreBackend(STORE_NAME, useExtensionStore);
+  initPegasusZustandStoreBackend(STORE_NAME, useExtensionStore, {
+    storageStrategy: 'session',
+  });
 export const extensionStoreReady = () =>
   pegasusZustandStoreReady(STORE_NAME, useExtensionStore);

--- a/packages/example-extension/wxt.config.ts
+++ b/packages/example-extension/wxt.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   debug: !!process.env.DEBUG_WXT,
   manifest: (configEnv) => {
     const manifestConf: UserManifest = {
-      permissions: ['tabs'],
+      permissions: ['tabs', 'storage'],
       web_accessible_resources: [
         {
           extension_ids: [],

--- a/packages/store/src/StoreCommunicationBridge.ts
+++ b/packages/store/src/StoreCommunicationBridge.ts
@@ -21,7 +21,7 @@ export class StoreCommunicationBridge<
   constructor(
     private readonly store: IPegasusStore<S, A>,
     private readonly serializer: SerializerFn<S | A>,
-    private readonly deserializer: DeserializerFn<A>,
+    private readonly deserializer: DeserializerFn<S | A>,
   ) {}
 
   fetchState(_message: PegasusRPCMessage): string {
@@ -36,7 +36,7 @@ export class StoreCommunicationBridge<
     serializedMessage: string,
   ): Promise<string> {
     return this.serializer(
-      await this.store.dispatch(this.deserializer(serializedMessage)),
+      await this.store.dispatch(this.deserializer(serializedMessage) as A),
     );
   }
 }

--- a/packages/store/src/StoreStorage.ts
+++ b/packages/store/src/StoreStorage.ts
@@ -1,0 +1,99 @@
+import {definePegasusBrowserAPI} from '@webext-pegasus/transport';
+
+import {
+  DeserializerFn,
+  PegasusStoreAction,
+  PegasusStoreAnyAction,
+  SerializerFn,
+} from './types';
+
+export type StoreStorageStrategy = 'local' | 'session' | 'sync' | undefined;
+
+export class StoreStorage<
+  S,
+  A extends PegasusStoreAction = PegasusStoreAnyAction,
+> {
+  private readonly browser;
+  constructor(
+    private readonly storeName: string,
+    private readonly storageStrategy: StoreStorageStrategy,
+    private readonly serializer: SerializerFn<S | A>,
+    private readonly deserializer: DeserializerFn<S | A>,
+  ) {
+    const browser = definePegasusBrowserAPI();
+    if (browser === null) {
+      throw new Error('Browser API not available');
+    }
+    this.browser = browser;
+  }
+
+  async getState(): Promise<S | undefined> {
+    if (this.storageStrategy === undefined) {
+      return undefined;
+    }
+
+    this.checkPermissions();
+
+    const key = this.getStorageKey();
+
+    const {[key]: stateStr} = await this.getStoreStorage()
+      .get(key)
+      .catch((error) => {
+        console.error(
+          `Error loading Pegasus Store "${this.storeName}" state from storage.`,
+          error,
+        );
+
+        return {[key]: undefined};
+      });
+
+    let state: S | undefined = undefined;
+    if (typeof stateStr === 'string') {
+      try {
+        state = this.deserializer(stateStr) as S;
+      } catch (err) {
+        console.warn('Error deserializing preloaded state:', err, stateStr);
+      }
+    }
+
+    return state;
+  }
+
+  async setState(state: S): Promise<void> {
+    if (this.storageStrategy === undefined) {
+      return;
+    }
+    this.checkPermissions();
+
+    const key = this.getStorageKey();
+
+    await this.getStoreStorage()
+      .set({
+        [key]: this.serializer(state),
+      })
+      .catch((error) => {
+        console.error(
+          `Error saving Pegasus Store "${this.storeName}" state to storage.`,
+          error,
+        );
+      });
+  }
+
+  private getStorageKey() {
+    return `pegasus-store/${this.storeName}`;
+  }
+
+  private getStoreStorage() {
+    const storageStrategySetting = this.storageStrategy ?? 'session';
+
+    return this.browser.storage[storageStrategySetting];
+  }
+
+  private checkPermissions() {
+    if (this.browser.storage === undefined) {
+      throw new Error(
+        'Error initializing storage for Pegasus Store, ensure that you have "storage" permission enabled for your extension.',
+      );
+    }
+  }
+}

--- a/packages/store/src/__tests__/unit/initPegasusStoreBackend.test.ts
+++ b/packages/store/src/__tests__/unit/initPegasusStoreBackend.test.ts
@@ -23,19 +23,19 @@ describe('initPegasusStoreBackend', () => {
 
   describe('on receiving messages', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let store: IPegasusStore<any, any>,
+    let storeInitFn: () => IPegasusStore<any, any>,
       payload: object,
       dispatch: jest.Mock<Dispatch>;
 
     beforeEach(function () {
       dispatch = jest.fn((action) => Promise.resolve(action));
-      store = {
+      storeInitFn = () => ({
         dispatch: dispatch,
         getState: () => ({}),
         subscribe: () => {
           return () => ({});
         },
-      };
+      });
 
       payload = {
         a: 'a',
@@ -49,7 +49,7 @@ describe('initPegasusStoreBackend', () => {
         () => {},
       );
 
-      initPegasusStoreBackend(store, {
+      await initPegasusStoreBackend(storeInitFn, {
         deserializer: noop,
         portName,
         serializer: noop,
@@ -77,7 +77,7 @@ describe('initPegasusStoreBackend', () => {
         () => {},
       );
 
-      initPegasusStoreBackend(store, {
+      await initPegasusStoreBackend(storeInitFn, {
         deserializer,
         portName,
         serializer,
@@ -103,7 +103,7 @@ describe('initPegasusStoreBackend', () => {
     });
   });
 
-  it('should serialize initial state and subsequent patches correctly', function () {
+  it('should serialize initial state and subsequent patches correctly', async function () {
     const onEventInitHandler = jest.fn();
     addPegasusEventHandler(
       `pegasusStore/${portName}/${MessageType.STATE}`,
@@ -155,7 +155,7 @@ describe('initPegasusStoreBackend', () => {
       },
     ];
 
-    initPegasusStoreBackend(store, {
+    await initPegasusStoreBackend(() => store, {
       deserializer,
       diffStrategy,
       portName,
@@ -177,7 +177,7 @@ describe('initPegasusStoreBackend', () => {
     subscribers.forEach((subscriber) => subscriber());
   });
 
-  it("should not send patches if state hasn't been changed", function () {
+  it("should not send patches if state hasn't been changed", async function () {
     const onEventPatchHandler = jest.fn();
     addPegasusEventHandler(
       `pegasusStore/${portName}/${MessageType.PATCH_STATE}`,
@@ -218,7 +218,7 @@ describe('initPegasusStoreBackend', () => {
       () => {},
     );
 
-    initPegasusStoreBackend(store, {
+    await initPegasusStoreBackend(() => store, {
       deserializer,
       portName,
       serializer,

--- a/packages/transport/background.ts
+++ b/packages/transport/background.ts
@@ -386,6 +386,7 @@ export function initPegasusTransport(): void {
   );
 
   initTransportAPI({
+    browser: browser,
     emitBroadcastEvent: eventRuntime.emitBroadcastEvent,
     onBroadcastEvent: eventRuntime.onBroadcastEvent,
     onMessage: messageRuntime.onMessage,

--- a/packages/transport/background.ts
+++ b/packages/transport/background.ts
@@ -354,7 +354,9 @@ export function initPegasusTransport(): void {
   let undeliveredEvents: InternalBroadcastEvent[] | undefined = [];
   // PersistentPort usually reconnects within 500ms
   setTimeout(() => {
-    Promise.all((undeliveredEvents as InternalBroadcastEvent[]).map(routeEvent)).catch(err => {
+    Promise.all(
+      (undeliveredEvents as InternalBroadcastEvent[]).map(routeEvent),
+    ).catch((err) => {
       console.error('Error while tying to deliver undelivered events:', err);
     });
     undeliveredEvents = undefined;
@@ -378,12 +380,9 @@ export function initPegasusTransport(): void {
     if (event.origin.context !== 'background') {
       eventRuntime.handleEvent(event);
     }
-  }
+  };
 
-  const eventRuntime = createBroadcastEventRuntime(
-    'background',
-    routeEvent,
-  );
+  const eventRuntime = createBroadcastEventRuntime('background', routeEvent);
 
   initTransportAPI({
     browser: browser,

--- a/packages/transport/content-script.ts
+++ b/packages/transport/content-script.ts
@@ -1,3 +1,5 @@
+import browser from 'webextension-polyfill';
+
 import {createBroadcastEventRuntime} from './src/BroadcastEventRuntime';
 import {createMessageRuntime} from './src/MessageRuntime';
 import {createPersistentPort} from './src/PersistentPort';
@@ -73,6 +75,7 @@ export function initPegasusTransport({
   }
 
   initTransportAPI({
+    browser: browser,
     emitBroadcastEvent: eventRuntime.emitBroadcastEvent,
     onBroadcastEvent: eventRuntime.onBroadcastEvent,
     onMessage: messageRuntime.onMessage,

--- a/packages/transport/devtools.ts
+++ b/packages/transport/devtools.ts
@@ -26,6 +26,7 @@ export function initPegasusTransport(): void {
   );
 
   initTransportAPI({
+    browser: browser,
     emitBroadcastEvent: eventRuntime.emitBroadcastEvent,
     onBroadcastEvent: eventRuntime.onBroadcastEvent,
     onMessage: messageRuntime.onMessage,

--- a/packages/transport/index.ts
+++ b/packages/transport/index.ts
@@ -1,10 +1,5 @@
+export {definePegasusBrowserAPI} from './src/definePegasusBrowserAPI';
 export {definePegasusEventBus} from './src/definePegasusEventBus';
 export {definePegasusMessageBus} from './src/definePegasusMessageBus';
 export {isInternalEndpoint} from './src/isInternalEndpoint';
-export {
-  Destination,
-  Endpoint,
-  OnMessageCallback,
-  PegasusMessage,
-  RuntimeContext,
-} from './src/types';
+export * from './src/types';

--- a/packages/transport/options.ts
+++ b/packages/transport/options.ts
@@ -1,3 +1,5 @@
+import browser from 'webextension-polyfill';
+
 import {createBroadcastEventRuntime} from './src/BroadcastEventRuntime';
 import {createMessageRuntime} from './src/MessageRuntime';
 import {createPersistentPort} from './src/PersistentPort';
@@ -19,6 +21,7 @@ export function initPegasusTransport(): void {
   });
 
   initTransportAPI({
+    browser: browser,
     emitBroadcastEvent: eventRuntime.emitBroadcastEvent,
     onBroadcastEvent: eventRuntime.onBroadcastEvent,
     onMessage: messageRuntime.onMessage,

--- a/packages/transport/popup.ts
+++ b/packages/transport/popup.ts
@@ -1,3 +1,5 @@
+import browser from 'webextension-polyfill';
+
 import {createBroadcastEventRuntime} from './src/BroadcastEventRuntime';
 import {createMessageRuntime} from './src/MessageRuntime';
 import {createPersistentPort} from './src/PersistentPort';
@@ -19,6 +21,7 @@ export function initPegasusTransport(): void {
   });
 
   initTransportAPI({
+    browser: browser,
     emitBroadcastEvent: eventRuntime.emitBroadcastEvent,
     onBroadcastEvent: eventRuntime.onBroadcastEvent,
     onMessage: messageRuntime.onMessage,

--- a/packages/transport/src/BroadcastEventRuntime.ts
+++ b/packages/transport/src/BroadcastEventRuntime.ts
@@ -1,14 +1,13 @@
 import type {
   PegasusMessage,
   RuntimeContext,
-  TransportBroadcastEventAPI,
 } from './types';
 import type {JsonValue} from 'type-fest';
 
 import {serializeError} from 'serialize-error';
 import uuid from 'tiny-uid';
 
-import {InternalBroadcastEvent} from './types-internal';
+import {InternalBroadcastEvent, TransportBroadcastEventAPI} from './types-internal';
 
 export interface BroadcastEventRuntime extends TransportBroadcastEventAPI {
   /**

--- a/packages/transport/src/BroadcastEventRuntime.ts
+++ b/packages/transport/src/BroadcastEventRuntime.ts
@@ -1,13 +1,13 @@
-import type {
-  PegasusMessage,
-  RuntimeContext,
-} from './types';
+import type {PegasusMessage, RuntimeContext} from './types';
 import type {JsonValue} from 'type-fest';
 
 import {serializeError} from 'serialize-error';
 import uuid from 'tiny-uid';
 
-import {InternalBroadcastEvent, TransportBroadcastEventAPI} from './types-internal';
+import {
+  InternalBroadcastEvent,
+  TransportBroadcastEventAPI,
+} from './types-internal';
 
 export interface BroadcastEventRuntime extends TransportBroadcastEventAPI {
   /**

--- a/packages/transport/src/MessageRuntime.ts
+++ b/packages/transport/src/MessageRuntime.ts
@@ -1,7 +1,4 @@
-import type {
-  OnMessageCallback,
-  RuntimeContext,
-} from './types';
+import type {OnMessageCallback, RuntimeContext} from './types';
 import type {InternalMessage, TransportMessagingAPI} from './types-internal';
 import type {JsonValue} from 'type-fest';
 

--- a/packages/transport/src/MessageRuntime.ts
+++ b/packages/transport/src/MessageRuntime.ts
@@ -1,9 +1,8 @@
 import type {
   OnMessageCallback,
   RuntimeContext,
-  TransportMessagingAPI,
 } from './types';
-import type {InternalMessage} from './types-internal';
+import type {InternalMessage, TransportMessagingAPI} from './types-internal';
 import type {JsonValue} from 'type-fest';
 
 import {serializeError} from 'serialize-error';

--- a/packages/transport/src/TransportAPI.ts
+++ b/packages/transport/src/TransportAPI.ts
@@ -1,4 +1,4 @@
-import {TransportAPI} from './types';
+import {TransportAPI} from './types-internal';
 
 let API: TransportAPI | null = null;
 

--- a/packages/transport/src/definePegasusBrowserAPI.ts
+++ b/packages/transport/src/definePegasusBrowserAPI.ts
@@ -1,0 +1,9 @@
+import { type Browser } from 'webextension-polyfill';
+
+import { getTransportAPI } from './TransportAPI';
+
+export function definePegasusBrowserAPI(): Browser | null {
+  const {browser} = getTransportAPI();
+
+  return browser;
+}

--- a/packages/transport/src/definePegasusBrowserAPI.ts
+++ b/packages/transport/src/definePegasusBrowserAPI.ts
@@ -1,6 +1,6 @@
-import { type Browser } from 'webextension-polyfill';
+import {type Browser} from 'webextension-polyfill';
 
-import { getTransportAPI } from './TransportAPI';
+import {getTransportAPI} from './TransportAPI';
 
 export function definePegasusBrowserAPI(): Browser | null {
   const {browser} = getTransportAPI();

--- a/packages/transport/src/definePegasusEventBus.test.ts
+++ b/packages/transport/src/definePegasusEventBus.test.ts
@@ -2,7 +2,8 @@
 import {JsonValue} from 'type-fest';
 
 import {definePegasusEventBus} from './definePegasusEventBus';
-import {PegasusMessage, TransportBroadcastEventAPI} from './types';
+import {PegasusMessage} from './types';
+import {TransportBroadcastEventAPI} from './types-internal';
 
 interface ProtocolMap {
   message1: void;

--- a/packages/transport/src/definePegasusEventBus.ts
+++ b/packages/transport/src/definePegasusEventBus.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {getTransportAPI} from './TransportAPI';
-import {TransportBroadcastEventAPI} from './types';
+import {TransportBroadcastEventAPI} from './types-internal';
 
 declare const MissingProtocolMap: unique symbol;
 type MissingProtocolMapType = typeof MissingProtocolMap;

--- a/packages/transport/src/definePegasusMessageBus.test.ts
+++ b/packages/transport/src/definePegasusMessageBus.test.ts
@@ -3,7 +3,7 @@ import {JsonValue} from 'type-fest';
 
 import {definePegasusMessageBus} from './definePegasusMessageBus';
 import {PegasusMessage} from './types';
-import { TransportMessagingAPI } from './types-internal';
+import {TransportMessagingAPI} from './types-internal';
 
 interface ProtocolMap {
   message1(): void;

--- a/packages/transport/src/definePegasusMessageBus.test.ts
+++ b/packages/transport/src/definePegasusMessageBus.test.ts
@@ -2,7 +2,8 @@
 import {JsonValue} from 'type-fest';
 
 import {definePegasusMessageBus} from './definePegasusMessageBus';
-import {PegasusMessage, TransportMessagingAPI} from './types';
+import {PegasusMessage} from './types';
+import { TransportMessagingAPI } from './types-internal';
 
 interface ProtocolMap {
   message1(): void;

--- a/packages/transport/src/definePegasusMessageBus.ts
+++ b/packages/transport/src/definePegasusMessageBus.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {getTransportAPI} from './TransportAPI';
-import { TransportMessagingAPI } from './types-internal';
+import {TransportMessagingAPI} from './types-internal';
 
 declare const MissingProtocolMap: unique symbol;
 type MissingProtocolMapType = typeof MissingProtocolMap;

--- a/packages/transport/src/definePegasusMessageBus.ts
+++ b/packages/transport/src/definePegasusMessageBus.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {getTransportAPI} from './TransportAPI';
-import {TransportMessagingAPI} from './types';
+import { TransportMessagingAPI } from './types-internal';
 
 declare const MissingProtocolMap: unique symbol;
 type MissingProtocolMapType = typeof MissingProtocolMap;

--- a/packages/transport/src/types-internal.ts
+++ b/packages/transport/src/types-internal.ts
@@ -1,6 +1,15 @@
 import {JsonValue} from 'type-fest';
 
-import {Endpoint} from './types';
+import {
+  Endpoint,
+  TransportBroadcastEventAPI,
+  TransportMessagingAPI,
+} from './types';
+
+export interface TransportAPI
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  extends TransportMessagingAPI,
+    TransportBroadcastEventAPI {}
 
 export interface InternalPacket {
   origin: Endpoint;

--- a/packages/transport/src/types-internal.ts
+++ b/packages/transport/src/types-internal.ts
@@ -1,5 +1,5 @@
 import {JsonValue} from 'type-fest';
-import { type Browser } from 'webextension-polyfill';
+import {type Browser} from 'webextension-polyfill';
 
 import {
   Destination,
@@ -64,7 +64,6 @@ export interface TransportBroadcastEventAPI<
     data: TProtocolMap[TType],
   ) => Promise<void>;
 }
-
 
 export interface TransportAPI
   extends TransportMessagingAPI,

--- a/packages/transport/src/types-internal.ts
+++ b/packages/transport/src/types-internal.ts
@@ -1,15 +1,75 @@
 import {JsonValue} from 'type-fest';
+import { type Browser } from 'webextension-polyfill';
 
 import {
+  Destination,
   Endpoint,
-  TransportBroadcastEventAPI,
-  TransportMessagingAPI,
+  OnMessageCallback,
+  PegasusMessage,
 } from './types';
 
-export interface TransportAPI
+export interface TransportBrowserAPI {
+  browser: Browser | null;
+}
+
+export interface TransportMessagingAPI<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TProtocolMap extends Record<string, any> = Record<string, any>,
+> {
+  /**
+   * Sends a message to some other part of your extension.
+   *
+   * Notes:
+   * - If there is no listener on the other side an error will be thrown where sendMessage was called.
+   * - Listener on the other may want to reply. Get the reply by awaiting the returned Promise
+   * - An error thrown in listener callback (in the destination context) will behave as usual, that is, bubble up, but the same error will also be thrown where sendMessage was called
+   * - If the listener receives the message but the destination disconnects (tab closure for exmaple) before responding, sendMessage will throw an error in the sender context.
+   */
+  sendMessage: <TType extends keyof TProtocolMap>(
+    messageID: TType,
+    data: GetMessageProtocolDataType<TProtocolMap[TType]>,
+    destination?: Destination,
+  ) => Proimsify<GetMessageProtocolReturnType<TProtocolMap[TType]>>;
+  /**
+   * Register one and only one listener, per messageId per context. That will be called upon sendMessage from other side.
+   * Optionally, send a response to sender by returning any value or if async a Promise.
+   */
+  onMessage: <TType extends keyof TProtocolMap>(
+    messageID: TType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    callback: OnMessageCallback<TProtocolMap, TType>,
+  ) => RemoveListenerCallback;
+}
+
+export interface TransportBroadcastEventAPI<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TProtocolMap extends Record<string, any> = Record<string, any>,
+> {
+  /**
+   * Broadcast Channel API alternative for browser extensions
+   * Allows basic communication between extension contexts (that is, windows, popups, devtools, content-scripts, background, etc...)
+   */
+  onBroadcastEvent: <TType extends keyof TProtocolMap>(
+    eventID: TType,
+    callback: (event: PegasusMessage<TProtocolMap[TType]>) => void,
+  ) => () => void;
+  /**
+   * Broadcast Channel API alternative for browser extensions
+   * Allows basic communication between extension contexts (that is, windows, popups, devtools, content-scripts, background, etc...)
+   *
+   * Emits an event, which can be of any kind of serialazible Object, to "every" listener in any extension context with the same extension.
+   */
+  emitBroadcastEvent: <TType extends keyof TProtocolMap>(
+    eventID: TType,
+    data: TProtocolMap[TType],
+  ) => Promise<void>;
+}
+
+
+export interface TransportAPI
   extends TransportMessagingAPI,
-    TransportBroadcastEventAPI {}
+    TransportBroadcastEventAPI,
+    TransportBrowserAPI {}
 
 export interface InternalPacket {
   origin: Endpoint;

--- a/packages/transport/src/types.ts
+++ b/packages/transport/src/types.ts
@@ -4,8 +4,6 @@ import {
   GetMessageProtocolDataType,
   GetMessageProtocolReturnType,
   MaybePromise,
-  Proimsify,
-  RemoveListenerCallback,
 } from './types-internal';
 
 export type RuntimeContext =
@@ -41,56 +39,3 @@ export type OnMessageCallback<
 > = (
   message: PegasusMessage<GetMessageProtocolDataType<TProtocolMap[TType]>>,
 ) => MaybePromise<GetMessageProtocolReturnType<TProtocolMap[TType]>>;
-
-export interface TransportMessagingAPI<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TProtocolMap extends Record<string, any> = Record<string, any>,
-> {
-  /**
-   * Sends a message to some other part of your extension.
-   *
-   * Notes:
-   * - If there is no listener on the other side an error will be thrown where sendMessage was called.
-   * - Listener on the other may want to reply. Get the reply by awaiting the returned Promise
-   * - An error thrown in listener callback (in the destination context) will behave as usual, that is, bubble up, but the same error will also be thrown where sendMessage was called
-   * - If the listener receives the message but the destination disconnects (tab closure for exmaple) before responding, sendMessage will throw an error in the sender context.
-   */
-  sendMessage: <TType extends keyof TProtocolMap>(
-    messageID: TType,
-    data: GetMessageProtocolDataType<TProtocolMap[TType]>,
-    destination?: Destination,
-  ) => Proimsify<GetMessageProtocolReturnType<TProtocolMap[TType]>>;
-  /**
-   * Register one and only one listener, per messageId per context. That will be called upon sendMessage from other side.
-   * Optionally, send a response to sender by returning any value or if async a Promise.
-   */
-  onMessage: <TType extends keyof TProtocolMap>(
-    messageID: TType,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: OnMessageCallback<TProtocolMap, TType>,
-  ) => RemoveListenerCallback;
-}
-
-export interface TransportBroadcastEventAPI<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TProtocolMap extends Record<string, any> = Record<string, any>,
-> {
-  /**
-   * Broadcast Channel API alternative for browser extensions
-   * Allows basic communication between extension contexts (that is, windows, popups, devtools, content-scripts, background, etc...)
-   */
-  onBroadcastEvent: <TType extends keyof TProtocolMap>(
-    eventID: TType,
-    callback: (event: PegasusMessage<TProtocolMap[TType]>) => void,
-  ) => () => void;
-  /**
-   * Broadcast Channel API alternative for browser extensions
-   * Allows basic communication between extension contexts (that is, windows, popups, devtools, content-scripts, background, etc...)
-   *
-   * Emits an event, which can be of any kind of serialazible Object, to "every" listener in any extension context with the same extension.
-   */
-  emitBroadcastEvent: <TType extends keyof TProtocolMap>(
-    eventID: TType,
-    data: TProtocolMap[TType],
-  ) => Promise<void>;
-}

--- a/packages/transport/src/types.ts
+++ b/packages/transport/src/types.ts
@@ -94,8 +94,3 @@ export interface TransportBroadcastEventAPI<
     data: TProtocolMap[TType],
   ) => Promise<void>;
 }
-
-export interface TransportAPI
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extends TransportMessagingAPI,
-    TransportBroadcastEventAPI {}

--- a/packages/transport/window.ts
+++ b/packages/transport/window.ts
@@ -39,6 +39,7 @@ export function initPegasusTransport({namespace}: Props = {}): void {
     win.enable();
   }
   initTransportAPI({
+    browser: null,
     emitBroadcastEvent: eventRuntime.emitBroadcastEvent,
     onBroadcastEvent: eventRuntime.onBroadcastEvent,
     onMessage: messageRuntime.onMessage,

--- a/test-utils/testPegasus.ts
+++ b/test-utils/testPegasus.ts
@@ -3,7 +3,7 @@ import type {PegasusMessage} from '../packages/transport';
 import {JsonValue} from 'type-fest';
 
 import {initTransportAPI} from '../packages/transport/src/TransportAPI';
-import {TransportAPI} from '../packages/transport/src/types';
+import {TransportAPI} from '../packages/transport/src/types-internal';
 
 const listeners: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
- feat(example-extension): Updated "renderStoreCounterUI" so it renders now current value in store to simplify debugging
- fix(@webext-pegasus/transport): Now events that were broadcasted on SW startup (before tabs or extension contexts had a change to open a port) will be dispatched correctly with 500ms delay
- feat(@webext-pegasus/transport): Added "definePegasusBrowserAPI" API
- feat(@webext-pegasus/store): Added ability to persist store state within `browser.storage`